### PR TITLE
Set tweet_mode to extended in configuration builder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"
     testRuntime "net.sourceforge.htmlunit:htmlunit:2.18"
     //twitter4j
-        compile 'org.twitter4j:twitter4j-core:4.0.4'
+        compile 'org.twitter4j:twitter4j-core:4.0.6'
         compile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.1') {
             //        exclude module: "commons-logging"
             //        exclude module: "xml-apis"

--- a/grails-app/services/com/novadge/social/TwitterService.groovy
+++ b/grails-app/services/com/novadge/social/TwitterService.groovy
@@ -50,6 +50,7 @@ class TwitterService {
                 .setOAuthConsumerKey(oAuthConsumerKey)
                 .setOAuthConsumerSecret(oAuthConsumerSecret)
                 .setTweetModeExtended(true)
+
         //use config object to get twitter factory object
         TwitterFactory tf = new TwitterFactory(cb.build());
         Twitter twitter = tf.getInstance();

--- a/grails-app/services/com/novadge/social/TwitterService.groovy
+++ b/grails-app/services/com/novadge/social/TwitterService.groovy
@@ -49,6 +49,7 @@ class TwitterService {
         cb.setDebugEnabled(true)
                 .setOAuthConsumerKey(oAuthConsumerKey)
                 .setOAuthConsumerSecret(oAuthConsumerSecret)
+                .setTweetModeExtended(true)
         //use config object to get twitter factory object
         TwitterFactory tf = new TwitterFactory(cb.build());
         Twitter twitter = tf.getInstance();
@@ -73,6 +74,7 @@ class TwitterService {
                 .setOAuthAccessToken(oAuthAccessToken)
                 .setOAuthAccessTokenSecret(oAuthAccessTokenSecret)
                 .setApplicationOnlyAuthEnabled(isApplicationOnlyAuth)
+                .setTweetModeExtended(true)
 
         TwitterFactory tf = new TwitterFactory(cb.build());
         // get twitter instance


### PR DESCRIPTION
Currently, the tweets fetched are shortened with `links` appended to the remainder. This pull request sets the tweet mode to extended to remove the url.